### PR TITLE
feat: implement full DID registry in Solidity with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ artifacts/
 cache/
 typechain-types/
 besu/data/
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+## Workflow Orchestration
+
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately — don't keep pushing
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguity
+
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean
+- Offload research, exploration, and parallel analysis to subagents
+- For complex problems, throw more compute at it via subagents
+- One task per subagent for focused execution
+
+
+### 3. Self-Improvement Loop
+- After ANY correction from the user: update `tasks/lessons.md` with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevant project
+
+
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "Would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "Is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes — don't over-engineer
+- Challenge your own work before presenting it
+
+
+### 6. Autonomous Bug Fixing
+- When given a bug report: just fix it. Don't ask for hand-holding
+- Point at logs, errors, failing tests — then resolve them
+- Zero context switching required from the user
+- Go fix failing CI tests without being told how
+
+
+## Task Management
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items  
+2. **Verify Plan**: Check in before starting implementation  
+3. **Track Progress**: Mark items complete as you go  
+4. **Explain Changes**: High-level summary at each step  
+5. **Document Results**: Add review section to `tasks/todo.md`  
+6. **Capture Lessons**: Update `tasks/lessons.md` after corrections  
+
+
+## Core Principles
+
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
+- **Minimal Impact**: Changes should only touch what's necessary. Avoid introducing bugs.can 

--- a/contracts/didController.sol
+++ b/contracts/didController.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "./didCore.sol";
-import "./didResolver.sol"; // Assuming DidResolver inherits DidRegistrar
+import "./didResolver.sol";
 import "./signatureVerifier.sol";
 
 /// @title DidController
@@ -18,12 +18,20 @@ contract didController is didResolver {
     error ExecutionFailed(bytes data);
     error UnauthorizedCaller();
     error InvalidPayload();
+    error MethodAlreadyExists();
+    error MethodNotFound();
+    error ServiceAlreadyExists();
+    error ServiceNotFound();
+    error ControllerAlreadyExists();
+    error ControllerNotFound();
+    error AuthenticationAlreadyExists();
+    error AuthenticationNotFound();
 
     // Controller Routing & Payload Validation
 
     /// @notice Updates an existing DID Document
     function updateDid(
-        DidDocument calldata doc,
+        DidDocument memory doc,
         bytes calldata signature,
         address controller
     ) external {
@@ -40,10 +48,29 @@ contract didController is didResolver {
         bytes32 payloadHash = keccak256(abi.encodePacked(doc.id, "update", nonces[doc.id]));
         require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
 
-        // State Mutation
-        record.document.controller = doc.controller;
+        // State Mutation — replace all document fields
+        delete record.document.controller;
+        for (uint i = 0; i < doc.controller.length; i++) {
+            record.document.controller.push(doc.controller[i]);
+        }
+
+        delete record.document.verificationMethods;
+        for (uint i = 0; i < doc.verificationMethods.length; i++) {
+            record.document.verificationMethods.push(doc.verificationMethods[i]);
+        }
+
+        delete record.document.authentication;
+        for (uint i = 0; i < doc.authentication.length; i++) {
+            record.document.authentication.push(doc.authentication[i]);
+        }
+
+        delete record.document.services;
+        for (uint i = 0; i < doc.services.length; i++) {
+            record.document.services.push(doc.services[i]);
+        }
+
         record.metadata.updated = block.timestamp;
-        
+
         nonces[doc.id]++;
 
         // Emit history event
@@ -58,7 +85,7 @@ contract didController is didResolver {
         bytes calldata signature,
         address controller
     ) external returns (bytes memory) {
-        
+
         DidRecord storage record = registry[did];
         if (record.state != DidState.Active) {
             revert UnauthorizedCaller();
@@ -75,7 +102,7 @@ contract didController is didResolver {
 
         // Low-level EVM execution on the target
         (bool success, bytes memory result) = targetContract.call(payload);
-        
+
         if (!success) {
             revert ExecutionFailed(result);
         }
@@ -84,5 +111,216 @@ contract didController is didResolver {
         emit CrossContractExecuted(did, targetContract, success);
 
         return result;
+    }
+
+    /// @notice Adds a VerificationMethod to an existing DID document
+    function addVerificationMethod(
+        string calldata did,
+        VerificationMethod calldata method,
+        bytes calldata signature,
+        address controller
+    ) external {
+        DidRecord storage record = registry[did];
+        if (record.state != DidState.Active) revert UnauthorizedCaller();
+
+        // Reject duplicate method IDs
+        VerificationMethod[] storage vms = record.document.verificationMethods;
+        for (uint i = 0; i < vms.length; i++) {
+            if (keccak256(bytes(vms[i].id)) == keccak256(bytes(method.id))) revert MethodAlreadyExists();
+        }
+
+        bytes32 payloadHash = keccak256(abi.encodePacked(did, "addVerificationMethod", method.id, nonces[did]));
+        require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
+
+        vms.push(method);
+        record.metadata.updated = block.timestamp;
+        nonces[did]++;
+        emit DidUpdated(did, block.timestamp);
+    }
+
+    /// @notice Removes a VerificationMethod from an existing DID document by method ID
+    function removeVerificationMethod(
+        string calldata did,
+        string calldata methodId,
+        bytes calldata signature,
+        address controller
+    ) external {
+        DidRecord storage record = registry[did];
+        if (record.state != DidState.Active) revert UnauthorizedCaller();
+
+        bytes32 payloadHash = keccak256(abi.encodePacked(did, "removeVerificationMethod", methodId, nonces[did]));
+        require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
+
+        VerificationMethod[] storage vms = record.document.verificationMethods;
+        for (uint i = 0; i < vms.length; i++) {
+            if (keccak256(bytes(vms[i].id)) == keccak256(bytes(methodId))) {
+                vms[i] = vms[vms.length - 1]; // swap with last
+                vms.pop();
+                record.metadata.updated = block.timestamp;
+                nonces[did]++;
+                emit DidUpdated(did, block.timestamp);
+                return;
+            }
+        }
+        revert MethodNotFound();
+    }
+
+    /// @notice Adds a Service endpoint to an existing DID document
+    function addService(
+        string calldata did,
+        Service calldata service,
+        bytes calldata signature,
+        address controller
+    ) external {
+        DidRecord storage record = registry[did];
+        if (record.state != DidState.Active) revert UnauthorizedCaller();
+
+        // Reject duplicate service IDs
+        Service[] storage services = record.document.services;
+        for (uint i = 0; i < services.length; i++) {
+            if (keccak256(bytes(services[i].id)) == keccak256(bytes(service.id))) revert ServiceAlreadyExists();
+        }
+
+        bytes32 payloadHash = keccak256(abi.encodePacked(did, "addService", service.id, nonces[did]));
+        require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
+
+        services.push(service);
+        record.metadata.updated = block.timestamp;
+        nonces[did]++;
+        emit DidUpdated(did, block.timestamp);
+    }
+
+    /// @notice Removes a Service endpoint from an existing DID document by service ID
+    function removeService(
+        string calldata did,
+        string calldata serviceId,
+        bytes calldata signature,
+        address controller
+    ) external {
+        DidRecord storage record = registry[did];
+        if (record.state != DidState.Active) revert UnauthorizedCaller();
+
+        bytes32 payloadHash = keccak256(abi.encodePacked(did, "removeService", serviceId, nonces[did]));
+        require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
+
+        Service[] storage services = record.document.services;
+        for (uint i = 0; i < services.length; i++) {
+            if (keccak256(bytes(services[i].id)) == keccak256(bytes(serviceId))) {
+                services[i] = services[services.length - 1]; // swap with last
+                services.pop();
+                record.metadata.updated = block.timestamp;
+                nonces[did]++;
+                emit DidUpdated(did, block.timestamp);
+                return;
+            }
+        }
+        revert ServiceNotFound();
+    }
+
+    /// @notice Adds a controller DID string to the controller[] list of an existing DID document
+    function addController(
+        string calldata did,
+        string calldata newController,
+        bytes calldata signature,
+        address controller
+    ) external {
+        DidRecord storage record = registry[did];
+        if (record.state != DidState.Active) revert UnauthorizedCaller();
+
+        string[] storage controllers = record.document.controller;
+        for (uint i = 0; i < controllers.length; i++) {
+            if (keccak256(bytes(controllers[i])) == keccak256(bytes(newController))) revert ControllerAlreadyExists();
+        }
+
+        bytes32 payloadHash = keccak256(abi.encodePacked(did, "addController", newController, nonces[did]));
+        require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
+
+        controllers.push(newController);
+        record.metadata.updated = block.timestamp;
+        nonces[did]++;
+        emit DidUpdated(did, block.timestamp);
+    }
+
+    /// @notice Removes a controller DID string from the controller[] list of an existing DID document
+    function removeController(
+        string calldata did,
+        string calldata controllerToRemove,
+        bytes calldata signature,
+        address controller
+    ) external {
+        DidRecord storage record = registry[did];
+        if (record.state != DidState.Active) revert UnauthorizedCaller();
+
+        bytes32 payloadHash = keccak256(abi.encodePacked(did, "removeController", controllerToRemove, nonces[did]));
+        require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
+
+        string[] storage controllers = record.document.controller;
+        for (uint i = 0; i < controllers.length; i++) {
+            if (keccak256(bytes(controllers[i])) == keccak256(bytes(controllerToRemove))) {
+                controllers[i] = controllers[controllers.length - 1];
+                controllers.pop();
+                record.metadata.updated = block.timestamp;
+                nonces[did]++;
+                emit DidUpdated(did, block.timestamp);
+                return;
+            }
+        }
+        revert ControllerNotFound();
+    }
+
+    /// @notice Adds a verification method ID reference to the authentication[] relationship list
+    function addAuthentication(
+        string calldata did,
+        string calldata methodId,
+        bytes calldata signature,
+        address controller
+    ) external {
+        DidRecord storage record = registry[did];
+        if (record.state != DidState.Active) revert UnauthorizedCaller();
+
+        string[] storage auth = record.document.authentication;
+        for (uint i = 0; i < auth.length; i++) {
+            if (keccak256(bytes(auth[i])) == keccak256(bytes(methodId))) revert AuthenticationAlreadyExists();
+        }
+
+        bytes32 payloadHash = keccak256(abi.encodePacked(did, "addAuthentication", methodId, nonces[did]));
+        require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
+
+        auth.push(methodId);
+        record.metadata.updated = block.timestamp;
+        nonces[did]++;
+        emit DidUpdated(did, block.timestamp);
+    }
+
+    /// @notice Removes a verification method ID reference from the authentication[] relationship list
+    function removeAuthentication(
+        string calldata did,
+        string calldata methodId,
+        bytes calldata signature,
+        address controller
+    ) external {
+        DidRecord storage record = registry[did];
+        if (record.state != DidState.Active) revert UnauthorizedCaller();
+
+        bytes32 payloadHash = keccak256(abi.encodePacked(did, "removeAuthentication", methodId, nonces[did]));
+        require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
+
+        string[] storage auth = record.document.authentication;
+        for (uint i = 0; i < auth.length; i++) {
+            if (keccak256(bytes(auth[i])) == keccak256(bytes(methodId))) {
+                auth[i] = auth[auth.length - 1];
+                auth.pop();
+                record.metadata.updated = block.timestamp;
+                nonces[did]++;
+                emit DidUpdated(did, block.timestamp);
+                return;
+            }
+        }
+        revert AuthenticationNotFound();
+    }
+
+    /// @notice Returns the current state of a DID (Unregistered, Active, Deactivated)
+    function getDidState(string calldata did) external view returns (DidState) {
+        return registry[did].state;
     }
 }

--- a/contracts/didRegistrar.sol
+++ b/contracts/didRegistrar.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "./didCore.sol"; // Ensure this exactly matches the file name
+import "./didCore.sol";
+import "./signatureVerifier.sol";
 
 contract didRegistrar {
     mapping(string => DidRecord) internal registry;
@@ -16,7 +17,7 @@ contract didRegistrar {
 
     // Core Registrar Logic
     // Added 'controller' to args representing the EVM address of the signer
-    function createDid(DidDocument calldata doc, bytes calldata signature, address controller) external returns (string memory) {
+    function createDid(DidDocument memory doc, bytes calldata signature, address controller) external returns (string memory) {
         if (registry[doc.id].state != DidState.Unregistered) {
             revert DocumentAlreadyExists();
         }
@@ -24,19 +25,29 @@ contract didRegistrar {
         // 1. Construct the payload hash from the DID and current nonce
         bytes32 payloadHash = keccak256(abi.encodePacked(doc.id, nonces[doc.id]));
 
-        // 2. Call the correct library function
+        // 2. Verify signature
         require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
 
         DidRecord storage record = registry[doc.id];
-        
+
         record.document.id = doc.id;
-        record.document.controller = doc.controller;
+
+        for (uint i = 0; i < doc.controller.length; i++) {
+            record.document.controller.push(doc.controller[i]);
+        }
+        for (uint i = 0; i < doc.verificationMethods.length; i++) {
+            record.document.verificationMethods.push(doc.verificationMethods[i]);
+        }
+        for (uint i = 0; i < doc.authentication.length; i++) {
+            record.document.authentication.push(doc.authentication[i]);
+        }
+        for (uint i = 0; i < doc.services.length; i++) {
+            record.document.services.push(doc.services[i]);
+        }
+
         record.state = DidState.Active;
         record.metadata.created = block.timestamp;
         record.metadata.updated = block.timestamp;
-
-        // Note: For inner nested arrays in `doc` (like verificationMethods), 
-        // you will need to map/push them manually into the storage pointer if required.
 
         nonces[doc.id]++;
 
@@ -49,38 +60,18 @@ contract didRegistrar {
             revert("DID is not active");
         }
 
-            // 1. Construct the payload hash from the DID and current nonce
+        // 1. Construct the payload hash from the DID and current nonce
         bytes32 payloadHash = keccak256(abi.encodePacked(did, nonces[did]));
 
-            // 2. Verify authorization
+        // 2. Verify authorization
         require(SignatureVerifier.verifyEVMController(payloadHash, signature, controller), "Invalid Signature");
 
-            // 3. Update state
+        // 3. Update state
         DidRecord storage record = registry[did];
         record.state = DidState.Deactivated;
         record.metadata.updated = block.timestamp;
-            
+
         nonces[did]++;
         emit DidDeactivated(did, block.timestamp);
-        }
-}
-
-library SignatureVerifier {
-    function verifyEVMController(bytes32 payloadHash, bytes memory signature, address controller) internal pure returns (bool) {
-        bytes32 ethSignedMessageHash = keccak256(
-            abi.encodePacked("\x19Ethereum Signed Message:\n32", payloadHash)
-        );
-        
-        (bytes32 r, bytes32 s, uint8 v) = splitSignature(signature);
-        return ecrecover(ethSignedMessageHash, v, r, s) == controller;
-    }
-
-    function splitSignature(bytes memory sig) internal pure returns (bytes32 r, bytes32 s, uint8 v) {
-        require(sig.length == 65, "invalid signature length");
-        assembly {
-            r := mload(add(sig, 32))
-            s := mload(add(sig, 64))
-            v := byte(0, mload(add(sig, 96)))
-        }
     }
 }

--- a/contracts/didVerification.sol
+++ b/contracts/didVerification.sol
@@ -2,37 +2,66 @@
 pragma solidity ^0.8.20;
 
 import "./didCore.sol";
-import "./signatureVerifier.sol"; // Assuming this is where your ecrecover logic lives
 
 library didVerification {
-    
+
     error VerificationMethodNotFound();
     error UnauthorizedRelationship();
+    error UnsupportedRelationshipType();
 
-    /// @notice Checks if a controller is authorized to perform an action using a specific verification relationship
+    /// @notice Checks if a signer is authorized under a specific verification relationship.
+    /// @dev Walks the relationship array (e.g. authentication), finds each referenced
+    ///      VerificationMethod, and checks whether publicKeyMultibase encodes the signer address.
+    ///      publicKeyMultibase is expected to be abi.encode(address) — a 32-byte ABI-padded address.
+    /// @param doc         The DID document to check against (storage ref for gas efficiency)
+    /// @param relationshipType  One of: "authentication" (others will revert UnsupportedRelationshipType)
+    /// @param signer      The EVM address claiming authorization
+    /// @return true if the signer is found in the relationship, false otherwise
     function verifyRelationship(
         DidDocument storage doc,
-        string calldata relationshipType, // e.g., "authentication", "assertionMethod"
+        string calldata relationshipType,
         address signer
     ) internal view returns (bool) {
-        // 1. Traverse document relationships based on relationshipType
-        // 2. Find the referenced VerificationMethod
-        // 3. Confirm the 'signer' matches the key material in that VerificationMethod
-        
-        return true; // Return true if valid, revert or false otherwise
+        if (keccak256(bytes(relationshipType)) == keccak256(bytes("authentication"))) {
+            return _checkRelationship(doc, doc.authentication, signer);
+        }
+
+        revert UnsupportedRelationshipType();
     }
 
     /// @notice Helper to find a specific VerificationMethod by its ID fragment
     function findVerificationMethod(
-        DidDocument storage doc, 
+        DidDocument storage doc,
         string calldata methodId
     ) internal view returns (VerificationMethod memory) {
         for (uint i = 0; i < doc.verificationMethods.length; i++) {
-            // Note: String comparison requires keccak256 in Solidity
-            if (keccak256(abi.encodePacked(doc.verificationMethods[i].id)) == keccak256(abi.encodePacked(methodId))) {
+            if (keccak256(bytes(doc.verificationMethods[i].id)) == keccak256(bytes(methodId))) {
                 return doc.verificationMethods[i];
             }
         }
         revert VerificationMethodNotFound();
+    }
+
+    /// @dev For each method ID reference in the relationship array, resolves the VerificationMethod
+    ///      and checks if its publicKeyMultibase encodes the signer address.
+    function _checkRelationship(
+        DidDocument storage doc,
+        string[] storage relationship,
+        address signer
+    ) private view returns (bool) {
+        for (uint i = 0; i < relationship.length; i++) {
+            // Find the referenced VerificationMethod in the document
+            for (uint j = 0; j < doc.verificationMethods.length; j++) {
+                if (keccak256(bytes(doc.verificationMethods[j].id)) == keccak256(bytes(relationship[i]))) {
+                    // publicKeyMultibase is abi.encode(address) — 32 bytes, ABI-padded
+                    if (doc.verificationMethods[j].publicKeyMultibase.length == 32) {
+                        address encoded = abi.decode(doc.verificationMethods[j].publicKeyMultibase, (address));
+                        if (encoded == signer) return true;
+                    }
+                    break; // method found but key didn't match; move to next relationship entry
+                }
+            }
+        }
+        return false;
     }
 }

--- a/contracts/signatureVerifier.sol
+++ b/contracts/signatureVerifier.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-library signatureVerifier {
+library SignatureVerifier {
     
     /// @notice Verifies an ECDSA SECP256k1 signature against an EVM address (controller)
     /// @param payloadHash The keccak256 hash of the payload data

--- a/contracts/test/DidVerificationHarness.sol
+++ b/contracts/test/DidVerificationHarness.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../didCore.sol";
+import "../didVerification.sol";
+
+/// @dev Thin wrapper that exposes didVerification internal functions for testing
+contract DidVerificationHarness {
+    DidDocument private _doc;
+
+    function setDoc(DidDocument memory doc) external {
+        _doc.id = doc.id;
+
+        delete _doc.controller;
+        for (uint i = 0; i < doc.controller.length; i++) {
+            _doc.controller.push(doc.controller[i]);
+        }
+
+        delete _doc.verificationMethods;
+        for (uint i = 0; i < doc.verificationMethods.length; i++) {
+            _doc.verificationMethods.push(doc.verificationMethods[i]);
+        }
+
+        delete _doc.authentication;
+        for (uint i = 0; i < doc.authentication.length; i++) {
+            _doc.authentication.push(doc.authentication[i]);
+        }
+
+        delete _doc.services;
+        for (uint i = 0; i < doc.services.length; i++) {
+            _doc.services.push(doc.services[i]);
+        }
+    }
+
+    function verifyRelationship(string calldata relationshipType, address signer) external view returns (bool) {
+        return didVerification.verifyRelationship(_doc, relationshipType, signer);
+    }
+
+    function findVerificationMethod(string calldata methodId) external view returns (VerificationMethod memory) {
+        return didVerification.findVerificationMethod(_doc, methodId);
+    }
+}

--- a/contracts/test/MockTarget.sol
+++ b/contracts/test/MockTarget.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @dev Simple target contract for executeCrossContract tests
+contract MockTarget {
+    uint256 public value;
+
+    function setValue(uint256 _value) external {
+        value = _value;
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,6 +8,7 @@ const config: HardhatUserConfig = {
     version: "0.8.24",
     settings: {
       optimizer: { enabled: true, runs: 200 },
+      viaIR: true,
     },
   },
   networks: {

--- a/scripts/deploy/deployDIDRegistry.ts
+++ b/scripts/deploy/deployDIDRegistry.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Smoke-test deploy: deploys Lock.sol to verify the toolchain works end-to-end.
-// Full DIDRegistry deploy implemented in Issue #3.
+// Deploys didController (the top-level DID registry contract) to the configured network.
 import hre, { ethers } from "hardhat";
 import * as fs from "fs";
 
@@ -9,24 +8,21 @@ async function main() {
   console.log("Deploying with account:", deployer.address);
   console.log("Account balance:", (await deployer.provider.getBalance(deployer.address)).toString());
 
-  const ONE_YEAR = 365 * 24 * 60 * 60;
-  const unlockTime = Math.floor(Date.now() / 1000) + ONE_YEAR;
+  const DidController = await ethers.getContractFactory("didController");
+  const didController = await DidController.deploy();
+  await didController.waitForDeployment();
 
-  const Lock = await ethers.getContractFactory("Lock");
-  const lock = await Lock.deploy(unlockTime, { value: ethers.parseEther("0.001") });
-  await lock.waitForDeployment();
-
-  const address = await lock.getAddress();
-  const tx = lock.deploymentTransaction();
+  const address = await didController.getAddress();
+  const tx = didController.deploymentTransaction();
   const receipt = await deployer.provider.getTransactionReceipt(tx!.hash);
 
-  console.log("Lock deployed to:", address);
+  console.log("didController deployed to:", address);
   console.log("Transaction hash:", tx?.hash);
   console.log("Receipt status:", receipt?.status); // 1 = success
 
   const output = {
     network: hre.network.name,
-    Lock: address,
+    didController: address,
     deployedAt: new Date().toISOString(),
     txHash: tx?.hash,
   };

--- a/test/did/DIDRegistry.test.ts
+++ b/test/did/DIDRegistry.test.ts
@@ -1,64 +1,571 @@
 import { expect } from "chai";
-import hre from "hardhat";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
 
-describe("Smoke test — toolchain", () => {
-  it("should deploy the sample Lock contract and return a valid non-null address", async () => {
-    const ONE_YEAR = 365 * 24 * 60 * 60;
-    const unlockTime = Math.floor(Date.now() / 1000) + ONE_YEAR;
-    const Lock = await hre.ethers.getContractFactory("Lock");
-    const lock = await Lock.deploy(unlockTime, { value: hre.ethers.parseEther("0.001") });
-    await lock.waitForDeployment();
+// ─── constants ────────────────────────────────────────────────────────────────
 
-    const address = await lock.getAddress();
-    const receipt = await hre.ethers.provider.getTransactionReceipt(
-      lock.deploymentTransaction()!.hash
-    );
+const DID            = "did:example:123";
+const VM_ID          = `${DID}#key-1`;
+const SERVICE_ID     = `${DID}#service-1`;
+const CONTROLLER_DID = "did:example:controller";
 
-    expect(address).to.not.equal(hre.ethers.ZeroAddress);
-    expect(receipt?.status).to.equal(1);
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+function encodeAddr(addr: string): string {
+  return ethers.AbiCoder.defaultAbiCoder().encode(["address"], [addr]);
+}
+
+function makeDoc(signerAddr: string) {
+  return {
+    id: DID,
+    controller: [CONTROLLER_DID],
+    verificationMethods: [
+      {
+        id: VM_ID,
+        controller: DID,
+        keyType: "EcdsaSecp256k1RecoveryMethod2020",
+        publicKeyMultibase: encodeAddr(signerAddr),
+      },
+    ],
+    authentication: [VM_ID],
+    services: [
+      { id: SERVICE_ID, serviceType: "LinkedDomains", serviceEndpoint: "https://example.com" },
+    ],
+  };
+}
+
+// Hash types that match abi.encodePacked in each contract function
+function h(types: string[], values: unknown[]): string {
+  return ethers.keccak256(ethers.solidityPacked(types, values));
+}
+
+// signer.signMessage(bytes) prepends "\x19Ethereum Signed Message:\n32" — matches ecrecover in contract
+async function sign(signer: HardhatEthersSigner, hash: string) {
+  return signer.signMessage(ethers.getBytes(hash));
+}
+
+// One signing helper per contract function, mirroring its exact payloadHash construction
+const sig = {
+  create:           (s: HardhatEthersSigner, did: string, nonce: bigint) =>
+    sign(s, h(["string","uint256"], [did, nonce])),
+  deactivate:       (s: HardhatEthersSigner, did: string, nonce: bigint) =>
+    sign(s, h(["string","uint256"], [did, nonce])),
+  update:           (s: HardhatEthersSigner, did: string, nonce: bigint) =>
+    sign(s, h(["string","string","uint256"], [did, "update", nonce])),
+  crossContract:    (s: HardhatEthersSigner, did: string, target: string, payload: string, nonce: bigint) =>
+    sign(s, h(["string","address","bytes","uint256"], [did, target, payload, nonce])),
+  addVM:            (s: HardhatEthersSigner, did: string, methodId: string, nonce: bigint) =>
+    sign(s, h(["string","string","string","uint256"], [did, "addVerificationMethod", methodId, nonce])),
+  removeVM:         (s: HardhatEthersSigner, did: string, methodId: string, nonce: bigint) =>
+    sign(s, h(["string","string","string","uint256"], [did, "removeVerificationMethod", methodId, nonce])),
+  addService:       (s: HardhatEthersSigner, did: string, serviceId: string, nonce: bigint) =>
+    sign(s, h(["string","string","string","uint256"], [did, "addService", serviceId, nonce])),
+  removeService:    (s: HardhatEthersSigner, did: string, serviceId: string, nonce: bigint) =>
+    sign(s, h(["string","string","string","uint256"], [did, "removeService", serviceId, nonce])),
+  addController:    (s: HardhatEthersSigner, did: string, ctrl: string, nonce: bigint) =>
+    sign(s, h(["string","string","string","uint256"], [did, "addController", ctrl, nonce])),
+  removeController: (s: HardhatEthersSigner, did: string, ctrl: string, nonce: bigint) =>
+    sign(s, h(["string","string","string","uint256"], [did, "removeController", ctrl, nonce])),
+  addAuth:          (s: HardhatEthersSigner, did: string, methodId: string, nonce: bigint) =>
+    sign(s, h(["string","string","string","uint256"], [did, "addAuthentication", methodId, nonce])),
+  removeAuth:       (s: HardhatEthersSigner, did: string, methodId: string, nonce: bigint) =>
+    sign(s, h(["string","string","string","uint256"], [did, "removeAuthentication", methodId, nonce])),
+};
+
+// ─── suite ────────────────────────────────────────────────────────────────────
+
+describe("DID Registry", function () {
+  let registry: any;
+  let owner: HardhatEthersSigner;
+  let other: HardhatEthersSigner;
+
+  beforeEach(async function () {
+    [owner, other] = await ethers.getSigners();
+    registry = await (await ethers.getContractFactory("didController")).deploy();
   });
-});
 
-describe("DIDRegistry — contract skeleton", () => {
-  it("should compile and expose all 4 function signatures in the ABI", async () => {
-    const artifact = await hre.artifacts.readArtifact("DIDRegistry");
-    const functionNames = artifact.abi
-      .filter((x: any) => x.type === "function")
-      .map((x: any) => x.name);
+  async function createDid() {
+    const nonce = await registry.nonces(DID);
+    await registry.createDid(makeDoc(owner.address), await sig.create(owner, DID, nonce), owner.address);
+  }
 
-    expect(functionNames).to.include("createDID");
-    expect(functionNames).to.include("resolveDID");
-    expect(functionNames).to.include("updateDID");
-    expect(functionNames).to.include("deactivateDID");
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("createDid", function () {
+    it("returns the DID id", async function () {
+      const nonce = await registry.nonces(DID);
+      const s     = await sig.create(owner, DID, nonce);
+      expect(await registry.createDid.staticCall(makeDoc(owner.address), s, owner.address)).to.equal(DID);
+    });
+
+    it("stores all nested document fields", async function () {
+      await createDid();
+      const [doc] = await registry.resolve(DID);
+      expect(doc.verificationMethods[0].id).to.equal(VM_ID);
+      expect(doc.services[0].id).to.equal(SERVICE_ID);
+      expect(doc.authentication[0]).to.equal(VM_ID);
+      expect(doc.controller[0]).to.equal(CONTROLLER_DID);
+    });
+
+    it("emits DidCreated", async function () {
+      const nonce = await registry.nonces(DID);
+      const s     = await sig.create(owner, DID, nonce);
+      await expect(registry.createDid(makeDoc(owner.address), s, owner.address))
+        .to.emit(registry, "DidCreated").withArgs(DID, anyValue);
+    });
+
+    it("increments nonce to 1", async function () {
+      await createDid();
+      expect(await registry.nonces(DID)).to.equal(1n);
+    });
+
+    it("reverts if DID already exists", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      const s     = await sig.create(owner, DID, nonce);
+      await expect(registry.createDid(makeDoc(owner.address), s, owner.address))
+        .to.be.revertedWithCustomError(registry, "DocumentAlreadyExists");
+    });
+
+    it("reverts on wrong signer", async function () {
+      const nonce = await registry.nonces(DID);
+      const s     = await sig.create(other, DID, nonce); // signed by other, claimed as owner
+      await expect(registry.createDid(makeDoc(owner.address), s, owner.address))
+        .to.be.revertedWith("Invalid Signature");
+    });
   });
 
-  it("should expose all 3 event signatures in the ABI", async () => {
-    const artifact = await hre.artifacts.readArtifact("DIDRegistry");
-    const eventNames = artifact.abi
-      .filter((x: any) => x.type === "event")
-      .map((x: any) => x.name);
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("resolve", function () {
+    it("returns document and metadata for an active DID", async function () {
+      await createDid();
+      const [doc, meta] = await registry.resolve(DID);
+      expect(doc.id).to.equal(DID);
+      expect(meta.deactivated).to.equal(false);
+      expect(meta.created).to.be.gt(0n);
+    });
 
-    expect(eventNames).to.include("DIDCreated");
-    expect(eventNames).to.include("DIDUpdated");
-    expect(eventNames).to.include("DIDDeactivated");
+    it("reverts for an unregistered DID", async function () {
+      await expect(registry.resolve("did:unknown:999"))
+        .to.be.revertedWithCustomError(registry, "DocumentNotFound");
+    });
   });
 
-  it("should expose REGISTRAR_ROLE and ADMIN_ROLE as public constants in the ABI", async () => {
-    const artifact = await hre.artifacts.readArtifact("DIDRegistry");
-    const functionNames = artifact.abi
-      .filter((x: any) => x.type === "function")
-      .map((x: any) => x.name);
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("dereferenceVerificationMethod", function () {
+    it("returns the VerificationMethod by fragment ID", async function () {
+      await createDid();
+      const vm = await registry.dereferenceVerificationMethod(DID, VM_ID);
+      expect(vm.id).to.equal(VM_ID);
+      expect(vm.keyType).to.equal("EcdsaSecp256k1RecoveryMethod2020");
+    });
 
-    expect(functionNames).to.include("REGISTRAR_ROLE");
-    expect(functionNames).to.include("ADMIN_ROLE");
+    it("reverts if DID not found", async function () {
+      await expect(registry.dereferenceVerificationMethod("did:unknown:999", VM_ID))
+        .to.be.revertedWithCustomError(registry, "DocumentNotFound");
+    });
+
+    it("reverts if fragment not found", async function () {
+      await createDid();
+      await expect(registry.dereferenceVerificationMethod(DID, `${DID}#nonexistent`))
+        .to.be.revertedWithCustomError(registry, "FragmentNotFound");
+    });
   });
 
-  it("should mark resolveDID as a view function in the ABI", async () => {
-    const artifact = await hre.artifacts.readArtifact("DIDRegistry");
-    const resolveFn = artifact.abi.find(
-      (x: any) => x.type === "function" && x.name === "resolveDID"
-    );
-    expect(resolveFn).to.not.be.undefined;
-    expect(resolveFn.stateMutability).to.equal("view");
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("updateDid", function () {
+    it("replaces all document fields and emits DidUpdated", async function () {
+      await createDid();
+      const newVMId    = `${DID}#key-2`;
+      const updatedDoc = {
+        id: DID,
+        controller: ["did:example:new-controller"],
+        verificationMethods: [
+          { id: newVMId, controller: DID, keyType: "Ed25519VerificationKey2020", publicKeyMultibase: encodeAddr(owner.address) },
+        ],
+        authentication: [newVMId],
+        services: [],
+      };
+      const nonce = await registry.nonces(DID);
+      await expect(registry.updateDid(updatedDoc, await sig.update(owner, DID, nonce), owner.address))
+        .to.emit(registry, "DidUpdated");
+      const [doc] = await registry.resolve(DID);
+      expect(doc.verificationMethods[0].id).to.equal(newVMId);
+      expect(doc.controller[0]).to.equal("did:example:new-controller");
+      expect(doc.services.length).to.equal(0);
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.updateDid(makeDoc(owner.address), await sig.update(owner, DID, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "UnauthorizedCaller");
+    });
+
+    it("reverts on wrong signer", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.updateDid(makeDoc(owner.address), await sig.update(other, DID, nonce), owner.address))
+        .to.be.revertedWith("Invalid Signature");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("deactivateDid", function () {
+    it("sets state to Deactivated and emits DidDeactivated", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.deactivateDid(DID, await sig.deactivate(owner, DID, nonce), owner.address))
+        .to.emit(registry, "DidDeactivated").withArgs(DID, anyValue);
+      expect(await registry.getDidState(DID)).to.equal(2n);
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.deactivateDid(DID, await sig.deactivate(owner, DID, nonce), owner.address))
+        .to.be.revertedWith("DID is not active");
+    });
+
+    it("reverts on wrong signer", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.deactivateDid(DID, await sig.deactivate(other, DID, nonce), owner.address))
+        .to.be.revertedWith("Invalid Signature");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("getDidState", function () {
+    it("returns 0 (Unregistered) for unknown DID", async function () {
+      expect(await registry.getDidState("did:unknown:0")).to.equal(0n);
+    });
+
+    it("returns 1 (Active) after creation", async function () {
+      await createDid();
+      expect(await registry.getDidState(DID)).to.equal(1n);
+    });
+
+    it("returns 2 (Deactivated) after deactivation", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await registry.deactivateDid(DID, await sig.deactivate(owner, DID, nonce), owner.address);
+      expect(await registry.getDidState(DID)).to.equal(2n);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("executeCrossContract", function () {
+    let target: any;
+    let targetAddr: string;
+    let payload: string;
+
+    beforeEach(async function () {
+      target     = await (await ethers.getContractFactory("MockTarget")).deploy();
+      targetAddr = await target.getAddress();
+      payload    = target.interface.encodeFunctionData("setValue", [42n]);
+    });
+
+    it("calls the target and mutates its state", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await registry.executeCrossContract(DID, targetAddr, payload, await sig.crossContract(owner, DID, targetAddr, payload, nonce), owner.address);
+      expect(await target.value()).to.equal(42n);
+    });
+
+    it("emits CrossContractExecuted", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.executeCrossContract(DID, targetAddr, payload, await sig.crossContract(owner, DID, targetAddr, payload, nonce), owner.address))
+        .to.emit(registry, "CrossContractExecuted").withArgs(DID, targetAddr, true);
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.executeCrossContract(DID, targetAddr, payload, await sig.crossContract(owner, DID, targetAddr, payload, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "UnauthorizedCaller");
+    });
+
+    it("reverts on zero-address target", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.executeCrossContract(DID, ethers.ZeroAddress, payload, await sig.crossContract(owner, DID, ethers.ZeroAddress, payload, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "InvalidPayload");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("addVerificationMethod", function () {
+    const NEW_VM_ID = `${DID}#key-2`;
+    const newVM     = (addr: string) => ({
+      id: NEW_VM_ID, controller: DID, keyType: "EcdsaSecp256k1RecoveryMethod2020", publicKeyMultibase: encodeAddr(addr),
+    });
+
+    it("appends the method and emits DidUpdated", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addVerificationMethod(DID, newVM(owner.address), await sig.addVM(owner, DID, NEW_VM_ID, nonce), owner.address))
+        .to.emit(registry, "DidUpdated");
+      const [doc] = await registry.resolve(DID);
+      expect(doc.verificationMethods.length).to.equal(2);
+      expect(doc.verificationMethods[1].id).to.equal(NEW_VM_ID);
+    });
+
+    it("reverts on duplicate method ID", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addVerificationMethod(DID, { ...newVM(owner.address), id: VM_ID }, await sig.addVM(owner, DID, VM_ID, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "MethodAlreadyExists");
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addVerificationMethod(DID, newVM(owner.address), await sig.addVM(owner, DID, NEW_VM_ID, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "UnauthorizedCaller");
+    });
+
+    it("reverts on wrong signer", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addVerificationMethod(DID, newVM(owner.address), await sig.addVM(other, DID, NEW_VM_ID, nonce), owner.address))
+        .to.be.revertedWith("Invalid Signature");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("removeVerificationMethod", function () {
+    it("removes the method and emits DidUpdated", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeVerificationMethod(DID, VM_ID, await sig.removeVM(owner, DID, VM_ID, nonce), owner.address))
+        .to.emit(registry, "DidUpdated");
+      const [doc] = await registry.resolve(DID);
+      expect(doc.verificationMethods.length).to.equal(0);
+    });
+
+    it("reverts if method not found", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeVerificationMethod(DID, `${DID}#nonexistent`, await sig.removeVM(owner, DID, `${DID}#nonexistent`, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "MethodNotFound");
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeVerificationMethod(DID, VM_ID, await sig.removeVM(owner, DID, VM_ID, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "UnauthorizedCaller");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("addService", function () {
+    const NEW_SVC = `${DID}#service-2`;
+    const newSvc  = () => ({ id: NEW_SVC, serviceType: "DIDCommMessaging", serviceEndpoint: "https://example.com/didcomm" });
+
+    it("appends the service and emits DidUpdated", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addService(DID, newSvc(), await sig.addService(owner, DID, NEW_SVC, nonce), owner.address))
+        .to.emit(registry, "DidUpdated");
+      const [doc] = await registry.resolve(DID);
+      expect(doc.services.length).to.equal(2);
+      expect(doc.services[1].id).to.equal(NEW_SVC);
+    });
+
+    it("reverts on duplicate service ID", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addService(DID, { ...newSvc(), id: SERVICE_ID }, await sig.addService(owner, DID, SERVICE_ID, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "ServiceAlreadyExists");
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addService(DID, newSvc(), await sig.addService(owner, DID, NEW_SVC, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "UnauthorizedCaller");
+    });
+
+    it("reverts on wrong signer", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addService(DID, newSvc(), await sig.addService(other, DID, NEW_SVC, nonce), owner.address))
+        .to.be.revertedWith("Invalid Signature");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("removeService", function () {
+    it("removes the service and emits DidUpdated", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeService(DID, SERVICE_ID, await sig.removeService(owner, DID, SERVICE_ID, nonce), owner.address))
+        .to.emit(registry, "DidUpdated");
+      const [doc] = await registry.resolve(DID);
+      expect(doc.services.length).to.equal(0);
+    });
+
+    it("reverts if service not found", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeService(DID, `${DID}#nonexistent`, await sig.removeService(owner, DID, `${DID}#nonexistent`, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "ServiceNotFound");
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeService(DID, SERVICE_ID, await sig.removeService(owner, DID, SERVICE_ID, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "UnauthorizedCaller");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("addController", function () {
+    const NEW_CTRL = "did:example:new-controller";
+
+    it("appends the controller and emits DidUpdated", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addController(DID, NEW_CTRL, await sig.addController(owner, DID, NEW_CTRL, nonce), owner.address))
+        .to.emit(registry, "DidUpdated");
+      const [doc] = await registry.resolve(DID);
+      expect(doc.controller).to.include(NEW_CTRL);
+    });
+
+    it("reverts on duplicate controller", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addController(DID, CONTROLLER_DID, await sig.addController(owner, DID, CONTROLLER_DID, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "ControllerAlreadyExists");
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addController(DID, NEW_CTRL, await sig.addController(owner, DID, NEW_CTRL, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "UnauthorizedCaller");
+    });
+
+    it("reverts on wrong signer", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addController(DID, NEW_CTRL, await sig.addController(other, DID, NEW_CTRL, nonce), owner.address))
+        .to.be.revertedWith("Invalid Signature");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("removeController", function () {
+    it("removes the controller and emits DidUpdated", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeController(DID, CONTROLLER_DID, await sig.removeController(owner, DID, CONTROLLER_DID, nonce), owner.address))
+        .to.emit(registry, "DidUpdated");
+      const [doc] = await registry.resolve(DID);
+      expect(doc.controller).to.not.include(CONTROLLER_DID);
+    });
+
+    it("reverts if controller not found", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeController(DID, "did:example:nonexistent", await sig.removeController(owner, DID, "did:example:nonexistent", nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "ControllerNotFound");
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeController(DID, CONTROLLER_DID, await sig.removeController(owner, DID, CONTROLLER_DID, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "UnauthorizedCaller");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("addAuthentication", function () {
+    const NEW_AUTH = `${DID}#key-3`;
+
+    it("appends the method reference and emits DidUpdated", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addAuthentication(DID, NEW_AUTH, await sig.addAuth(owner, DID, NEW_AUTH, nonce), owner.address))
+        .to.emit(registry, "DidUpdated");
+      const [doc] = await registry.resolve(DID);
+      expect(doc.authentication).to.include(NEW_AUTH);
+    });
+
+    it("reverts on duplicate authentication entry", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addAuthentication(DID, VM_ID, await sig.addAuth(owner, DID, VM_ID, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "AuthenticationAlreadyExists");
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addAuthentication(DID, NEW_AUTH, await sig.addAuth(owner, DID, NEW_AUTH, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "UnauthorizedCaller");
+    });
+
+    it("reverts on wrong signer", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.addAuthentication(DID, NEW_AUTH, await sig.addAuth(other, DID, NEW_AUTH, nonce), owner.address))
+        .to.be.revertedWith("Invalid Signature");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("removeAuthentication", function () {
+    it("removes the entry and emits DidUpdated", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeAuthentication(DID, VM_ID, await sig.removeAuth(owner, DID, VM_ID, nonce), owner.address))
+        .to.emit(registry, "DidUpdated");
+      const [doc] = await registry.resolve(DID);
+      expect(doc.authentication).to.not.include(VM_ID);
+    });
+
+    it("reverts if entry not found", async function () {
+      await createDid();
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeAuthentication(DID, `${DID}#nonexistent`, await sig.removeAuth(owner, DID, `${DID}#nonexistent`, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "AuthenticationNotFound");
+    });
+
+    it("reverts if DID is not active", async function () {
+      const nonce = await registry.nonces(DID);
+      await expect(registry.removeAuthentication(DID, VM_ID, await sig.removeAuth(owner, DID, VM_ID, nonce), owner.address))
+        .to.be.revertedWithCustomError(registry, "UnauthorizedCaller");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // verifyRelationship — tested via DidVerificationHarness (internal library)
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("verifyRelationship", function () {
+    let harness: any;
+
+    beforeEach(async function () {
+      harness = await (await ethers.getContractFactory("DidVerificationHarness")).deploy();
+      await harness.setDoc(makeDoc(owner.address));
+    });
+
+    it("returns true when signer address is in the authentication relationship", async function () {
+      expect(await harness.verifyRelationship("authentication", owner.address)).to.equal(true);
+    });
+
+    it("returns false when signer is not in the relationship", async function () {
+      expect(await harness.verifyRelationship("authentication", other.address)).to.equal(false);
+    });
+
+    it("reverts for unsupported relationship type", async function () {
+      await expect(harness.verifyRelationship("assertionMethod", owner.address))
+        .to.be.revertedWithCustomError(harness, "UnsupportedRelationshipType");
+    });
+
+    it("findVerificationMethod returns the correct method", async function () {
+      const vm = await harness.findVerificationMethod(VM_ID);
+      expect(vm.id).to.equal(VM_ID);
+    });
+
+    it("findVerificationMethod reverts for unknown ID", async function () {
+      await expect(harness.findVerificationMethod(`${DID}#nonexistent`))
+        .to.be.revertedWithCustomError(harness, "VerificationMethodNotFound");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fix compilation errors (calldata → memory for nested dynamic arrays, viaIR: true)
- Implement all 15 DID registry functions: createDid, updateDid, deactivateDid, resolve, dereferenceVerificationMethod, executeCrossContract, addVerificationMethod, removeVerificationMethod, addService, removeService, addController, removeController, addAuthentication, removeAuthentication, getDidState
- Implement verifyRelationship in didVerification library (walks authentication relationship, decodes publicKeyMultibase as ABI-encoded EVM address)
- Update deploy script to deploy didController (not Lock.sol)
- 57 passing tests covering all functions: happy paths, revert cases, event assertions, wrong-signer checks

## Test plan

- [x] `npx hardhat compile` — clean, no errors
- [x] `npx hardhat test` — 57/57 passing
- [x] `npx hardhat run scripts/deploy/deployDIDRegistry.ts --network localBasu` — receipt status 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)