### PR TITLE
feat: implement did:orcl format validation, SchemaRegistry, and CredD…

### DIFF
--- a/contracts/CredDefRegistry.sol
+++ b/contracts/CredDefRegistry.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./didCore.sol";
+import "./signatureVerifier.sol";
+import "./interfaces/IDidRegistry.sol";
+import "./interfaces/ISchemaRegistry.sol";
+
+/// @title CredDefRegistry
+/// @notice On-chain registry for AnonCreds credential definitions.
+///         Mirrors the CredDefReceiver boundary from the Fabric chaincode
+///         (pkg/acr/credentialDefinition.go).
+///
+/// CredDef uniqueness:  keccak256(abi.encode(issuerId, schemaId, tag))
+/// Authorization:       issuerId must be an Active DID; schemaId must exist.
+/// Replay protection:   nonce per issuerId.
+///
+/// The `value` field carries the CL public key material — treated as opaque
+/// bytes (map[string]any in Go → caller-encoded bytes in Solidity).
+contract CredDefRegistry {
+
+    // ── types ─────────────────────────────────────────────────────────────────
+
+    /// @dev Matches default:"CL" tag in credentialDefinition.go.
+    ///      Defined as an enum to make the constraint explicit rather than
+    ///      relying on an unchecked string.
+    enum CredDefType { CL }
+
+    struct CredDef {
+        bytes32     id;
+        string      issuerId;
+        bytes32     schemaId;
+        CredDefType credDefType;
+        string      tag;
+        bytes       value;
+    }
+
+    // ── storage ───────────────────────────────────────────────────────────────
+
+    mapping(bytes32 => CredDef) private credDefs;
+    mapping(string  => uint256) public  nonces;
+
+    IDidRegistry    public immutable didRegistry;
+    ISchemaRegistry public immutable schemaRegistry;
+
+    // ── events ────────────────────────────────────────────────────────────────
+
+    event CredDefPublished(
+        bytes32 indexed id,
+        string  issuerId,
+        bytes32 indexed schemaId,
+        string  tag
+    );
+
+    // ── errors ────────────────────────────────────────────────────────────────
+
+    error CredDefAlreadyExists();
+    error CredDefNotFound();
+    error InvalidCredDef();
+    error IssuerNotActive();
+    error SchemaNotFound();
+
+    // ── constructor ───────────────────────────────────────────────────────────
+
+    constructor(address _didRegistry, address _schemaRegistry) {
+        didRegistry    = IDidRegistry(_didRegistry);
+        schemaRegistry = ISchemaRegistry(_schemaRegistry);
+    }
+
+    // ── write ─────────────────────────────────────────────────────────────────
+
+    /// @notice Publish a new credential definition.
+    /// @param issuerId    DID of the issuer — must be Active in the DID registry.
+    /// @param schemaId    bytes32 key of an existing schema in SchemaRegistry.
+    /// @param credDefType Credential definition type — only CL is currently supported.
+    /// @param tag         Disambiguates multiple CredDefs for the same schema (no validation per spec).
+    /// @param value       Opaque CL public key material bytes.
+    /// @param signature   ECDSA signature over keccak256(issuerId ‖ schemaId ‖ tag ‖ nonce).
+    /// @param controller  EVM address that produced the signature.
+    /// @return id  Deterministic bytes32 key: keccak256(abi.encode(issuerId, schemaId, tag)).
+    function publishCredDef(
+        string      calldata issuerId,
+        bytes32              schemaId,
+        CredDefType          credDefType,
+        string      calldata tag,
+        bytes       calldata value,
+        bytes       calldata signature,
+        address              controller
+    ) external returns (bytes32 id) {
+        // ── validation (mirrors credentialDefinition.go L82/L85) ─────────────
+        if (bytes(issuerId).length == 0) revert InvalidCredDef();
+
+        // ── cross-contract: issuer DID must be Active ─────────────────────────
+        if (didRegistry.getDidState(issuerId) != DidState.Active) revert IssuerNotActive();
+
+        // ── cross-contract: referenced schema must exist ──────────────────────
+        if (!schemaRegistry.schemaExists(schemaId)) revert SchemaNotFound();
+
+        // ── uniqueness ────────────────────────────────────────────────────────
+        id = keccak256(abi.encode(issuerId, schemaId, tag));
+        if (bytes(credDefs[id].issuerId).length != 0) revert CredDefAlreadyExists();
+
+        // ── signature verification ────────────────────────────────────────────
+        bytes32 payloadHash = keccak256(
+            abi.encodePacked(issuerId, schemaId, tag, nonces[issuerId])
+        );
+        require(
+            SignatureVerifier.verifyEVMController(payloadHash, signature, controller),
+            "Invalid Signature"
+        );
+
+        // ── persist ───────────────────────────────────────────────────────────
+        CredDef storage cd = credDefs[id];
+        cd.id          = id;
+        cd.issuerId    = issuerId;
+        cd.schemaId    = schemaId;
+        cd.credDefType = credDefType;
+        cd.tag         = tag;
+        cd.value       = value;
+
+        nonces[issuerId]++;
+        emit CredDefPublished(id, issuerId, schemaId, tag);
+    }
+
+    // ── read ──────────────────────────────────────────────────────────────────
+
+    /// @notice Retrieve a credential definition by its id.
+    function getCredDef(bytes32 id) external view returns (CredDef memory) {
+        if (bytes(credDefs[id].issuerId).length == 0) revert CredDefNotFound();
+        return credDefs[id];
+    }
+}

--- a/contracts/SchemaRegistry.sol
+++ b/contracts/SchemaRegistry.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./didCore.sol";
+import "./signatureVerifier.sol";
+import "./interfaces/IDidRegistry.sol";
+
+/// @title SchemaRegistry
+/// @notice On-chain registry for AnonCreds credential schemas.
+///         Mirrors the SchemaReceiver boundary from the Fabric chaincode (pkg/acr/schema.go).
+///
+/// Schema uniqueness: keccak256(abi.encode(issuerId, name, version))
+/// Authorization:     issuerId must be an Active DID; ECDSA signature required.
+/// Replay protection: nonce per issuerId.
+contract SchemaRegistry {
+
+    // ── structs ───────────────────────────────────────────────────────────────
+
+    struct Schema {
+        bytes32     id;
+        string      issuerId;
+        string      name;
+        string      version;
+        string[]    attrNames;
+    }
+
+    // ── storage ───────────────────────────────────────────────────────────────
+
+    mapping(bytes32 => Schema) private schemas;
+    mapping(string  => uint256) public  nonces;
+
+    IDidRegistry public immutable didRegistry;
+
+    // ── events ────────────────────────────────────────────────────────────────
+
+    event SchemaPublished(
+        bytes32 indexed id,
+        string  issuerId,
+        string  name,
+        string  version
+    );
+
+    // ── errors ────────────────────────────────────────────────────────────────
+
+    error SchemaAlreadyExists();
+    error SchemaNotFound();
+    error InvalidSchema();
+    error IssuerNotActive();
+
+    // ── constructor ───────────────────────────────────────────────────────────
+
+    constructor(address _didRegistry) {
+        didRegistry = IDidRegistry(_didRegistry);
+    }
+
+    // ── write ─────────────────────────────────────────────────────────────────
+
+    /// @notice Publish a new credential schema.
+    /// @param issuerId  DID of the issuer — must be Active in the DID registry.
+    /// @param name      Human-readable schema name, non-empty.
+    /// @param version   Schema version string, non-empty.
+    /// @param attrNames Credential attribute names, at least one required.
+    /// @param signature ECDSA signature over keccak256(issuerId ‖ name ‖ version ‖ nonce).
+    /// @param controller EVM address that produced the signature.
+    /// @return id  Deterministic bytes32 key: keccak256(abi.encode(issuerId, name, version)).
+    function publishSchema(
+        string   calldata issuerId,
+        string   calldata name,
+        string   calldata version,
+        string[] calldata attrNames,
+        bytes    calldata signature,
+        address           controller
+    ) external returns (bytes32 id) {
+        // ── validation (mirrors schema.go field checks) ──────────────────────
+        if (
+            bytes(issuerId).length  == 0 ||
+            bytes(name).length      == 0 ||
+            bytes(version).length   == 0 ||
+            attrNames.length        == 0
+        ) revert InvalidSchema();
+
+        // ── authorization: issuer DID must be Active ─────────────────────────
+        if (didRegistry.getDidState(issuerId) != DidState.Active) revert IssuerNotActive();
+
+        // ── uniqueness ───────────────────────────────────────────────────────
+        id = keccak256(abi.encode(issuerId, name, version));
+        if (bytes(schemas[id].issuerId).length != 0) revert SchemaAlreadyExists();
+
+        // ── signature verification ───────────────────────────────────────────
+        bytes32 payloadHash = keccak256(
+            abi.encodePacked(issuerId, name, version, nonces[issuerId])
+        );
+        require(
+            SignatureVerifier.verifyEVMController(payloadHash, signature, controller),
+            "Invalid Signature"
+        );
+
+        // ── persist ──────────────────────────────────────────────────────────
+        Schema storage s = schemas[id];
+        s.id      = id;
+        s.issuerId = issuerId;
+        s.name    = name;
+        s.version = version;
+        for (uint i = 0; i < attrNames.length; i++) {
+            s.attrNames.push(attrNames[i]);
+        }
+
+        nonces[issuerId]++;
+        emit SchemaPublished(id, issuerId, name, version);
+    }
+
+    // ── read ──────────────────────────────────────────────────────────────────
+
+    /// @notice Retrieve a schema by its id.
+    function getSchema(bytes32 id) external view returns (Schema memory) {
+        if (bytes(schemas[id].issuerId).length == 0) revert SchemaNotFound();
+        return schemas[id];
+    }
+
+    /// @notice Returns true if a schema with the given id has been published.
+    ///         Used by CredDefRegistry for cross-contract validation.
+    function schemaExists(bytes32 id) external view returns (bool) {
+        return bytes(schemas[id].issuerId).length != 0;
+    }
+}

--- a/contracts/didController.sol
+++ b/contracts/didController.sol
@@ -35,13 +35,13 @@ contract didController is didResolver {
         bytes calldata signature,
         address controller
     ) external {
+        // Format validation first — fail fast before any storage read
+        _validateDid(doc.id);
+
         DidRecord storage record = registry[doc.id];
         if (record.state != DidState.Active) {
             revert UnauthorizedCaller();
         }
-
-        // Top-level Payload Validation
-        if (bytes(doc.id).length == 0) revert InvalidPayload();
 
         // Top-level Authorization routing
         // Encodes the action intent to prevent replay attacks across different functions

--- a/contracts/didRegistrar.sol
+++ b/contracts/didRegistrar.sol
@@ -14,10 +14,26 @@ contract didRegistrar {
 
     error DocumentAlreadyExists();
     error InvalidSignature();
+    error InvalidDidFormat();
+
+    /// @dev Validates the generic DID format: exactly 3 colon-separated segments
+    ///      (e.g. "did:orcl:uuid"). Matches the chaincode's only enforced invariant
+    ///      (authzXcc.go:199 — non-empty + parseable as ssi.URI with method + id).
+    function _validateDid(string memory did) internal pure {
+        bytes memory b = bytes(did);
+        if (b.length == 0) revert InvalidDidFormat();
+        uint8 colons;
+        for (uint i = 0; i < b.length; i++) {
+            if (b[i] == 0x3a) colons++; // 0x3a == ':'
+        }
+        if (colons != 2) revert InvalidDidFormat();
+    }
 
     // Core Registrar Logic
     // Added 'controller' to args representing the EVM address of the signer
     function createDid(DidDocument memory doc, bytes calldata signature, address controller) external returns (string memory) {
+        _validateDid(doc.id);
+
         if (registry[doc.id].state != DidState.Unregistered) {
             revert DocumentAlreadyExists();
         }

--- a/contracts/interfaces/IDidRegistry.sol
+++ b/contracts/interfaces/IDidRegistry.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../didCore.sol";
+
+/// @notice Minimal interface for cross-contract DID state queries
+interface IDidRegistry {
+    function getDidState(string calldata did) external view returns (DidState);
+}

--- a/contracts/interfaces/ISchemaRegistry.sol
+++ b/contracts/interfaces/ISchemaRegistry.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @notice Minimal interface for cross-contract schema existence queries
+interface ISchemaRegistry {
+    function schemaExists(bytes32 id) external view returns (bool);
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,130 @@
+# Implementation Plan
+
+## Status
+
+| Item | Done |
+|---|---|
+| DID document struct defined in Solidity | ✅ |
+| DID registry create function implemented | ✅ |
+| DID registry store/read implemented | ✅ |
+| DID registry update function implemented | ✅ |
+| DID registry deactivate function implemented | ✅ |
+| did:orcl:uuid identifier format implemented | ❌ |
+| DID path implemented for SCHEMA object | ❌ |
+| DID path implemented for CRED_DEF object | ❌ |
+
+---
+
+## Item 6 — did:orcl:uuid identifier format
+
+**Source reference:** authzXcc.go:199 — only enforcement is non-empty string after TrimSpace.
+**Decision:** Validate 3 colon-separated segments only (no method/UUID enforcement — matches chaincode).
+
+### Changes
+
+**contracts/didRegistrar.sol**
+- Add `error InvalidDidFormat()`
+- Add internal pure `_validateDid(string memory did)`:
+  - Revert if empty
+  - Iterate bytes and count colons — must equal exactly 2 (segments: did / method / id)
+- Call `_validateDid(doc.id)` as first line of `createDid()`
+
+**contracts/didController.sol**
+- Call `_validateDid(doc.id)` as first line of `updateDid()`
+
+---
+
+## Item 7 — DID path for SCHEMA object
+
+**Source reference:** schema.go:18-23 (struct fields), schema.go:52 (key format)
+**Decision:** Separate `SchemaRegistry` contract. Key by `keccak256(abi.encode(issuerId, name, version))` to replicate chaincode uniqueness semantics.
+
+### New file: contracts/SchemaRegistry.sol
+
+**Struct** (from schema.go):
+```
+string id         — content-derived key (hex of keccak256)
+string issuerId   — required non-empty  (ssi.URI in Go)
+string name       — required non-empty
+string version    — required non-empty
+string[] attrNames — required, min 1 element
+```
+
+**Storage:**
+```
+mapping(bytes32 => Schema) internal schemas
+mapping(string => uint256) public nonces   — keyed by issuerId
+```
+
+**Functions:**
+- `publishSchema(string issuerId, string name, string version, string[] attrNames, bytes sig, address controller) returns (bytes32)`
+  - Validate all fields
+  - Check schema not already published (revert `SchemaAlreadyExists`)
+  - Verify ECDSA sig: `keccak256(abi.encodePacked(issuerId, name, version, nonces[issuerId]))`
+  - Store, increment nonce, emit `SchemaPublished`
+- `getSchema(bytes32 id) returns (Schema memory)`
+  - Revert `SchemaNotFound` if empty
+
+**Events:** `SchemaPublished(bytes32 indexed id, string issuerId, string name, string version)`
+**Errors:** `SchemaAlreadyExists()`, `SchemaNotFound()`, `InvalidSchema()`
+
+---
+
+## Item 8 — DID path for CRED_DEF object
+
+**Source reference:** credentialDefinition.go:17-23 (struct), L82/L85 (validations), L114 (key format)
+**Decision:** Separate `CredDefRegistry` contract. Key by `keccak256(abi.encode(issuerId, schemaId, tag))` — allows multiple CredDefs per schema, unique per issuer+schema+tag.
+
+### New file: contracts/CredDefRegistry.sol
+
+**Enum + Struct** (from credentialDefinition.go):
+```
+enum CredDefType { CL }   — default:"CL" in Go source
+
+string id          — content-derived key
+string issuerId    — required non-empty  (L82)
+string schemaId    — required non-empty  (L85)
+CredDefType credDefType  — CL only for now
+string tag         — no validation in chaincode
+bytes value        — CL public key material (map[string]any in Go → raw bytes in Solidity)
+```
+
+**Storage:**
+```
+mapping(bytes32 => CredDef) internal credDefs
+mapping(string => uint256) public nonces   — keyed by issuerId
+```
+
+**Functions:**
+- `publishCredDef(string issuerId, string schemaId, CredDefType credDefType, string tag, bytes value, bytes sig, address controller) returns (bytes32)`
+  - Validate issuerId and schemaId non-empty
+  - Check cred def not already published (revert `CredDefAlreadyExists`)
+  - Verify ECDSA sig: `keccak256(abi.encodePacked(issuerId, schemaId, tag, nonces[issuerId]))`
+  - Store, increment nonce, emit `CredDefPublished`
+- `getCredDef(bytes32 id) returns (CredDef memory)`
+  - Revert `CredDefNotFound` if empty
+
+**Events:** `CredDefPublished(bytes32 indexed id, string issuerId, string schemaId, string tag)`
+**Errors:** `CredDefAlreadyExists()`, `CredDefNotFound()`, `InvalidCredDef()`
+
+---
+
+## Files to create/modify
+
+| File | Change |
+|---|---|
+| `contracts/didRegistrar.sol` | Add `_validateDid()`, call in `createDid()` |
+| `contracts/didController.sol` | Call `_validateDid()` in `updateDid()` |
+| `contracts/SchemaRegistry.sol` | New contract |
+| `contracts/CredDefRegistry.sol` | New contract |
+| `test/did/DIDRegistry.test.ts` | Add DID format validation tests |
+| `test/schema/SchemaRegistry.test.ts` | New test file |
+| `test/credDef/CredDefRegistry.test.ts` | New test file |
+
+---
+
+## Questions for user before implementing
+
+1. Should `SchemaRegistry` and `CredDefRegistry` verify that the `issuerId` is a registered active DID in `didController` before publishing? (Cross-contract call to `getDidState()`)
+2. Should all three contracts (`didController`, `SchemaRegistry`, `CredDefRegistry`) be deployed separately, or combined into one entry-point contract?
+3. For the `value` field in CredDef — should callers pass raw JSON as `bytes`, or is there a known struct to ABI-encode?

--- a/test/credDef/CredDefRegistry.test.ts
+++ b/test/credDef/CredDefRegistry.test.ts
@@ -1,0 +1,212 @@
+/**
+ * CredDefRegistry tests — written before implementation (TDD).
+ *
+ * Spec source: pkg/acr/credentialDefinition.go
+ *   - IssuerId:  required non-empty  (L82)
+ *   - SchemaId:  required non-empty, must exist in SchemaRegistry (L85)
+ *   - Type:      CredDefType enum — only CL supported (default:"CL")
+ *   - Tag:       no validation in chaincode
+ *   - Value:     CL public key material — arbitrary bytes
+ *   - Key:       keccak256(abi.encode(issuerId, schemaId, tag))
+ *
+ * Authorization: issuerId must be an active DID in the registry.
+ * Replay protection: nonce per issuerId, included in payload hash.
+ */
+import { expect } from "chai";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+// ─── constants ────────────────────────────────────────────────────────────────
+
+const ISSUER_DID  = "did:orcl:550e8400-e29b-41d4-a716-446655440000";
+const VM_ID       = `${ISSUER_DID}#key-1`;
+const SCHEMA_NAME = "EmployeeCredential";
+const SCHEMA_VER  = "1.0";
+const ATTR_NAMES  = ["firstName", "lastName", "employeeId"];
+const CD_TAG      = "default";
+const CD_VALUE    = ethers.toUtf8Bytes(JSON.stringify({ n: "abc123", s: "def456", rms: {}, r: {}, rctxt: "ghi", z: "jkl" }));
+const CL          = 0; // CredDefType.CL
+
+// ─── signing helpers ──────────────────────────────────────────────────────────
+
+function encodeAddr(addr: string): string {
+  return ethers.AbiCoder.defaultAbiCoder().encode(["address"], [addr]);
+}
+
+function makeIssuerDoc(addr: string) {
+  return {
+    id: ISSUER_DID,
+    controller: [ISSUER_DID],
+    verificationMethods: [
+      { id: VM_ID, controller: ISSUER_DID, keyType: "EcdsaSecp256k1RecoveryMethod2020", publicKeyMultibase: encodeAddr(addr) },
+    ],
+    authentication: [VM_ID],
+    services: [],
+  };
+}
+
+async function sign(signer: HardhatEthersSigner, hash: string) {
+  return signer.signMessage(ethers.getBytes(hash));
+}
+
+function h(types: string[], values: unknown[]) {
+  return ethers.keccak256(ethers.solidityPacked(types, values));
+}
+
+async function sigCreateDid(signer: HardhatEthersSigner, did: string, nonce: bigint) {
+  return sign(signer, h(["string", "uint256"], [did, nonce]));
+}
+
+async function sigPublishSchema(signer: HardhatEthersSigner, issuerId: string, name: string, version: string, nonce: bigint) {
+  return sign(signer, h(["string", "string", "string", "uint256"], [issuerId, name, version, nonce]));
+}
+
+async function sigPublishCredDef(
+  signer: HardhatEthersSigner,
+  issuerId: string,
+  schemaId: string, // bytes32 hex string
+  tag: string,
+  nonce: bigint
+) {
+  return sign(signer, h(["string", "bytes32", "string", "uint256"], [issuerId, schemaId, tag, nonce]));
+}
+
+// ─── suite ────────────────────────────────────────────────────────────────────
+
+describe("CredDefRegistry", function () {
+  let didRegistry: any;
+  let schemaRegistry: any;
+  let credDefRegistry: any;
+  let owner: HardhatEthersSigner;
+  let other: HardhatEthersSigner;
+  let schemaId: string; // bytes32
+
+  beforeEach(async function () {
+    [owner, other] = await ethers.getSigners();
+
+    // Deploy dependency chain
+    didRegistry    = await (await ethers.getContractFactory("didController")).deploy();
+    schemaRegistry = await (await ethers.getContractFactory("SchemaRegistry")).deploy(await didRegistry.getAddress());
+    credDefRegistry = await (await ethers.getContractFactory("CredDefRegistry")).deploy(
+      await didRegistry.getAddress(),
+      await schemaRegistry.getAddress()
+    );
+
+    // Register issuer DID
+    const didNonce = await didRegistry.nonces(ISSUER_DID);
+    await didRegistry.createDid(makeIssuerDoc(owner.address), await sigCreateDid(owner, ISSUER_DID, didNonce), owner.address);
+
+    // Publish a schema to reference in cred def tests
+    const schemaNonce = await schemaRegistry.nonces(ISSUER_DID);
+    const schemaSig   = await sigPublishSchema(owner, ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, schemaNonce);
+    const tx          = await schemaRegistry.publishSchema(ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, ATTR_NAMES, schemaSig, owner.address);
+    const receipt     = await tx.wait();
+    schemaId = receipt.logs[0].topics[1]; // bytes32 from SchemaPublished event
+  });
+
+  // ── publishCredDef ─────────────────────────────────────────────────────────
+
+  describe("publishCredDef", function () {
+    async function publish(
+      signer: HardhatEthersSigner = owner,
+      issuerId = ISSUER_DID,
+      sid = schemaId,
+      tag = CD_TAG,
+      value = CD_VALUE
+    ) {
+      const nonce = await credDefRegistry.nonces(issuerId);
+      const sig   = await sigPublishCredDef(signer, issuerId, sid, tag, nonce);
+      return credDefRegistry.publishCredDef(issuerId, sid, CL, tag, value, sig, signer.address);
+    }
+
+    it("returns a deterministic bytes32 id = keccak256(issuerId, schemaId, tag)", async function () {
+      const expected = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ["string", "bytes32", "string"],
+          [ISSUER_DID, schemaId, CD_TAG]
+        )
+      );
+      const nonce = await credDefRegistry.nonces(ISSUER_DID);
+      const sig   = await sigPublishCredDef(owner, ISSUER_DID, schemaId, CD_TAG, nonce);
+      const id    = await credDefRegistry.publishCredDef.staticCall(ISSUER_DID, schemaId, CL, CD_TAG, CD_VALUE, sig, owner.address);
+      expect(id).to.equal(expected);
+    });
+
+    it("stores all fields retrievable via getCredDef", async function () {
+      const tx      = await publish();
+      const receipt = await tx.wait();
+      const id      = receipt.logs[0].topics[1];
+      const cd      = await credDefRegistry.getCredDef(id);
+      expect(cd.issuerId).to.equal(ISSUER_DID);
+      expect(cd.schemaId).to.equal(schemaId);
+      expect(cd.credDefType).to.equal(CL);
+      expect(cd.tag).to.equal(CD_TAG);
+      expect(cd.value).to.equal(ethers.hexlify(CD_VALUE));
+    });
+
+    it("emits CredDefPublished with correct args", async function () {
+      const nonce = await credDefRegistry.nonces(ISSUER_DID);
+      const sig   = await sigPublishCredDef(owner, ISSUER_DID, schemaId, CD_TAG, nonce);
+      await expect(credDefRegistry.publishCredDef(ISSUER_DID, schemaId, CL, CD_TAG, CD_VALUE, sig, owner.address))
+        .to.emit(credDefRegistry, "CredDefPublished")
+        .withArgs(anyValue, ISSUER_DID, schemaId, CD_TAG);
+    });
+
+    it("increments nonce per issuerId after publish", async function () {
+      await publish();
+      expect(await credDefRegistry.nonces(ISSUER_DID)).to.equal(1n);
+    });
+
+    it("allows multiple CredDefs per schema with different tags", async function () {
+      await publish(owner, ISSUER_DID, schemaId, "tag-a");
+      await publish(owner, ISSUER_DID, schemaId, "tag-b");
+      // Both should succeed — different keys
+    });
+
+    it("reverts CredDefAlreadyExists on duplicate (same issuerId + schemaId + tag)", async function () {
+      await publish();
+      await expect(publish()).to.be.revertedWithCustomError(credDefRegistry, "CredDefAlreadyExists");
+    });
+
+    it("reverts InvalidCredDef when issuerId is empty", async function () {
+      const nonce = await credDefRegistry.nonces("");
+      const sig   = await sigPublishCredDef(owner, "", schemaId, CD_TAG, nonce);
+      await expect(credDefRegistry.publishCredDef("", schemaId, CL, CD_TAG, CD_VALUE, sig, owner.address))
+        .to.be.revertedWithCustomError(credDefRegistry, "InvalidCredDef");
+    });
+
+    it("reverts SchemaNotFound when schemaId does not exist in SchemaRegistry", async function () {
+      const fakeSchemaId = ethers.keccak256(ethers.toUtf8Bytes("nonexistent-schema"));
+      const nonce        = await credDefRegistry.nonces(ISSUER_DID);
+      const sig          = await sigPublishCredDef(owner, ISSUER_DID, fakeSchemaId, CD_TAG, nonce);
+      await expect(credDefRegistry.publishCredDef(ISSUER_DID, fakeSchemaId, CL, CD_TAG, CD_VALUE, sig, owner.address))
+        .to.be.revertedWithCustomError(credDefRegistry, "SchemaNotFound");
+    });
+
+    it("reverts IssuerNotActive when issuer DID is not registered", async function () {
+      const foreignDid = "did:orcl:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+      const nonce      = await credDefRegistry.nonces(foreignDid);
+      const sig        = await sigPublishCredDef(owner, foreignDid, schemaId, CD_TAG, nonce);
+      await expect(credDefRegistry.publishCredDef(foreignDid, schemaId, CL, CD_TAG, CD_VALUE, sig, owner.address))
+        .to.be.revertedWithCustomError(credDefRegistry, "IssuerNotActive");
+    });
+
+    it("reverts on wrong signer", async function () {
+      const nonce = await credDefRegistry.nonces(ISSUER_DID);
+      const sig   = await sigPublishCredDef(other, ISSUER_DID, schemaId, CD_TAG, nonce);
+      await expect(credDefRegistry.publishCredDef(ISSUER_DID, schemaId, CL, CD_TAG, CD_VALUE, sig, owner.address))
+        .to.be.revertedWith("Invalid Signature");
+    });
+  });
+
+  // ── getCredDef ─────────────────────────────────────────────────────────────
+
+  describe("getCredDef", function () {
+    it("reverts CredDefNotFound for an unknown id", async function () {
+      const unknownId = ethers.keccak256(ethers.toUtf8Bytes("nonexistent"));
+      await expect(credDefRegistry.getCredDef(unknownId))
+        .to.be.revertedWithCustomError(credDefRegistry, "CredDefNotFound");
+    });
+  });
+});

--- a/test/did/DIDRegistry.test.ts
+++ b/test/did/DIDRegistry.test.ts
@@ -91,6 +91,52 @@ describe("DID Registry", function () {
   }
 
   // ────────────────────────────────────────────────────────────────────────────
+  // DID format validation (authzXcc.go:199 — 3 colon-separated segments)
+  // ────────────────────────────────────────────────────────────────────────────
+  describe("DID format validation", function () {
+    async function tryCreate(did: string) {
+      const doc   = { ...makeDoc(owner.address), id: did };
+      const nonce = await registry.nonces(did);
+      const s     = await sig.create(owner, did, nonce);
+      return registry.createDid(doc, s, owner.address);
+    }
+
+    it("accepts did:orcl:uuid format", async function () {
+      const orclDid = "did:orcl:550e8400-e29b-41d4-a716-446655440000";
+      const doc     = { ...makeDoc(owner.address), id: orclDid };
+      const nonce   = await registry.nonces(orclDid);
+      const s       = await sig.create(owner, orclDid, nonce);
+      await expect(registry.createDid(doc, s, owner.address)).to.not.be.reverted;
+    });
+
+    it("accepts any string with exactly 2 colons", async function () {
+      await expect(tryCreate("did:example:123")).to.not.be.reverted;
+    });
+
+    it("reverts InvalidDidFormat for empty string", async function () {
+      await expect(tryCreate("")).to.be.revertedWithCustomError(registry, "InvalidDidFormat");
+    });
+
+    it("reverts InvalidDidFormat for only 1 colon (2 segments)", async function () {
+      await expect(tryCreate("did:example")).to.be.revertedWithCustomError(registry, "InvalidDidFormat");
+    });
+
+    it("reverts InvalidDidFormat for 3 colons (4 segments)", async function () {
+      await expect(tryCreate("did:orcl:uuid:extra")).to.be.revertedWithCustomError(registry, "InvalidDidFormat");
+    });
+
+    it("reverts InvalidDidFormat in updateDid as well", async function () {
+      await createDid();
+      const badDoc = { ...makeDoc(owner.address), id: "bad-format" };
+      const nonce  = await registry.nonces(DID);
+      const s      = await sig.update(owner, DID, nonce);
+      // updateDid validates doc.id — bad-format has 0 colons
+      await expect(registry.updateDid(badDoc, s, owner.address))
+        .to.be.revertedWithCustomError(registry, "InvalidDidFormat");
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
   describe("createDid", function () {
     it("returns the DID id", async function () {
       const nonce = await registry.nonces(DID);

--- a/test/schema/SchemaRegistry.test.ts
+++ b/test/schema/SchemaRegistry.test.ts
@@ -1,0 +1,223 @@
+/**
+ * SchemaRegistry tests — written before implementation (TDD).
+ *
+ * Spec source: pkg/acr/schema.go
+ *   - IssuerId: required non-empty
+ *   - Name:     required non-empty
+ *   - Version:  required non-empty
+ *   - AttrNames: required, min 1 element
+ *   - Key:      keccak256(abi.encode(issuerId, name, version))
+ *
+ * Authorization: issuerId must be an active DID in the registry.
+ * Replay protection: nonce per issuerId, included in payload hash.
+ */
+import { expect } from "chai";
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+import { ethers } from "hardhat";
+import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+
+// ─── constants ────────────────────────────────────────────────────────────────
+
+const ISSUER_DID  = "did:orcl:550e8400-e29b-41d4-a716-446655440000";
+const VM_ID       = `${ISSUER_DID}#key-1`;
+const SCHEMA_NAME = "EmployeeCredential";
+const SCHEMA_VER  = "1.0";
+const ATTR_NAMES  = ["firstName", "lastName", "employeeId"];
+
+// ─── signing helpers ──────────────────────────────────────────────────────────
+
+function encodeAddr(addr: string): string {
+  return ethers.AbiCoder.defaultAbiCoder().encode(["address"], [addr]);
+}
+
+function makeIssuerDoc(addr: string) {
+  return {
+    id: ISSUER_DID,
+    controller: [ISSUER_DID],
+    verificationMethods: [
+      { id: VM_ID, controller: ISSUER_DID, keyType: "EcdsaSecp256k1RecoveryMethod2020", publicKeyMultibase: encodeAddr(addr) },
+    ],
+    authentication: [VM_ID],
+    services: [],
+  };
+}
+
+async function sign(signer: HardhatEthersSigner, hash: string) {
+  return signer.signMessage(ethers.getBytes(hash));
+}
+
+function h(types: string[], values: unknown[]) {
+  return ethers.keccak256(ethers.solidityPacked(types, values));
+}
+
+async function sigCreateDid(signer: HardhatEthersSigner, did: string, nonce: bigint) {
+  return sign(signer, h(["string", "uint256"], [did, nonce]));
+}
+
+async function sigPublishSchema(
+  signer: HardhatEthersSigner,
+  issuerId: string,
+  name: string,
+  version: string,
+  nonce: bigint
+) {
+  return sign(signer, h(["string", "string", "string", "uint256"], [issuerId, name, version, nonce]));
+}
+
+// ─── suite ────────────────────────────────────────────────────────────────────
+
+describe("SchemaRegistry", function () {
+  let didRegistry: any;
+  let schemaRegistry: any;
+  let owner: HardhatEthersSigner;
+  let other: HardhatEthersSigner;
+
+  beforeEach(async function () {
+    [owner, other] = await ethers.getSigners();
+
+    // Deploy DID registry first — SchemaRegistry validates issuer DID state
+    didRegistry = await (await ethers.getContractFactory("didController")).deploy();
+
+    // Register the issuer DID so it is Active
+    const nonce = await didRegistry.nonces(ISSUER_DID);
+    await didRegistry.createDid(
+      makeIssuerDoc(owner.address),
+      await sigCreateDid(owner, ISSUER_DID, nonce),
+      owner.address
+    );
+
+    // Deploy SchemaRegistry, passing didRegistry address
+    schemaRegistry = await (
+      await ethers.getContractFactory("SchemaRegistry")
+    ).deploy(await didRegistry.getAddress());
+  });
+
+  // ── publishSchema ──────────────────────────────────────────────────────────
+
+  describe("publishSchema", function () {
+    async function publish(
+      signer: HardhatEthersSigner = owner,
+      issuerId = ISSUER_DID,
+      name = SCHEMA_NAME,
+      version = SCHEMA_VER,
+      attrNames = ATTR_NAMES
+    ) {
+      const nonce = await schemaRegistry.nonces(issuerId);
+      const sig   = await sigPublishSchema(signer, issuerId, name, version, nonce);
+      return schemaRegistry.publishSchema(issuerId, name, version, attrNames, sig, signer.address);
+    }
+
+    it("returns a deterministic bytes32 id = keccak256(issuerId, name, version)", async function () {
+      const expected = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ["string", "string", "string"],
+          [ISSUER_DID, SCHEMA_NAME, SCHEMA_VER]
+        )
+      );
+      const nonce = await schemaRegistry.nonces(ISSUER_DID);
+      const sig   = await sigPublishSchema(owner, ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, nonce);
+      const id    = await schemaRegistry.publishSchema.staticCall(ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, ATTR_NAMES, sig, owner.address);
+      expect(id).to.equal(expected);
+    });
+
+    it("stores all schema fields retrievable via getSchema", async function () {
+      const tx = await publish();
+      const receipt = await tx.wait();
+      const id   = receipt.logs[0].topics[1]; // SchemaPublished first indexed arg
+      const schema = await schemaRegistry.getSchema(id);
+      expect(schema.issuerId).to.equal(ISSUER_DID);
+      expect(schema.name).to.equal(SCHEMA_NAME);
+      expect(schema.version).to.equal(SCHEMA_VER);
+      expect(schema.attrNames).to.deep.equal(ATTR_NAMES);
+    });
+
+    it("emits SchemaPublished with correct args", async function () {
+      const nonce = await schemaRegistry.nonces(ISSUER_DID);
+      const sig   = await sigPublishSchema(owner, ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, nonce);
+      await expect(schemaRegistry.publishSchema(ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, ATTR_NAMES, sig, owner.address))
+        .to.emit(schemaRegistry, "SchemaPublished")
+        .withArgs(anyValue, ISSUER_DID, SCHEMA_NAME, SCHEMA_VER);
+    });
+
+    it("increments nonce per issuerId after publish", async function () {
+      await publish();
+      expect(await schemaRegistry.nonces(ISSUER_DID)).to.equal(1n);
+    });
+
+    it("reverts SchemaAlreadyExists on duplicate (same issuerId + name + version)", async function () {
+      await publish();
+      await expect(publish()).to.be.revertedWithCustomError(schemaRegistry, "SchemaAlreadyExists");
+    });
+
+    it("reverts InvalidSchema when issuerId is empty", async function () {
+      const nonce = await schemaRegistry.nonces("");
+      const sig   = await sigPublishSchema(owner, "", SCHEMA_NAME, SCHEMA_VER, nonce);
+      await expect(schemaRegistry.publishSchema("", SCHEMA_NAME, SCHEMA_VER, ATTR_NAMES, sig, owner.address))
+        .to.be.revertedWithCustomError(schemaRegistry, "InvalidSchema");
+    });
+
+    it("reverts InvalidSchema when name is empty", async function () {
+      const nonce = await schemaRegistry.nonces(ISSUER_DID);
+      const sig   = await sigPublishSchema(owner, ISSUER_DID, "", SCHEMA_VER, nonce);
+      await expect(schemaRegistry.publishSchema(ISSUER_DID, "", SCHEMA_VER, ATTR_NAMES, sig, owner.address))
+        .to.be.revertedWithCustomError(schemaRegistry, "InvalidSchema");
+    });
+
+    it("reverts InvalidSchema when version is empty", async function () {
+      const nonce = await schemaRegistry.nonces(ISSUER_DID);
+      const sig   = await sigPublishSchema(owner, ISSUER_DID, SCHEMA_NAME, "", nonce);
+      await expect(schemaRegistry.publishSchema(ISSUER_DID, SCHEMA_NAME, "", ATTR_NAMES, sig, owner.address))
+        .to.be.revertedWithCustomError(schemaRegistry, "InvalidSchema");
+    });
+
+    it("reverts InvalidSchema when attrNames is empty", async function () {
+      const nonce = await schemaRegistry.nonces(ISSUER_DID);
+      const sig   = await sigPublishSchema(owner, ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, nonce);
+      await expect(schemaRegistry.publishSchema(ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, [], sig, owner.address))
+        .to.be.revertedWithCustomError(schemaRegistry, "InvalidSchema");
+    });
+
+    it("reverts IssuerNotActive when issuer DID is not registered", async function () {
+      const foreignDid = "did:orcl:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+      const nonce      = await schemaRegistry.nonces(foreignDid);
+      const sig        = await sigPublishSchema(owner, foreignDid, SCHEMA_NAME, SCHEMA_VER, nonce);
+      await expect(schemaRegistry.publishSchema(foreignDid, SCHEMA_NAME, SCHEMA_VER, ATTR_NAMES, sig, owner.address))
+        .to.be.revertedWithCustomError(schemaRegistry, "IssuerNotActive");
+    });
+
+    it("reverts on wrong signer", async function () {
+      const nonce = await schemaRegistry.nonces(ISSUER_DID);
+      const sig   = await sigPublishSchema(other, ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, nonce);
+      await expect(schemaRegistry.publishSchema(ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, ATTR_NAMES, sig, owner.address))
+        .to.be.revertedWith("Invalid Signature");
+    });
+  });
+
+  // ── getSchema ──────────────────────────────────────────────────────────────
+
+  describe("getSchema", function () {
+    it("reverts SchemaNotFound for an unknown id", async function () {
+      const unknownId = ethers.keccak256(ethers.toUtf8Bytes("nonexistent"));
+      await expect(schemaRegistry.getSchema(unknownId))
+        .to.be.revertedWithCustomError(schemaRegistry, "SchemaNotFound");
+    });
+  });
+
+  // ── schemaExists ───────────────────────────────────────────────────────────
+
+  describe("schemaExists", function () {
+    it("returns false for unknown id", async function () {
+      expect(await schemaRegistry.schemaExists(ethers.keccak256(ethers.toUtf8Bytes("x")))).to.equal(false);
+    });
+
+    it("returns true after publish", async function () {
+      const nonce = await schemaRegistry.nonces(ISSUER_DID);
+      const sig   = await sigPublishSchema(owner, ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, nonce);
+      await schemaRegistry.publishSchema(ISSUER_DID, SCHEMA_NAME, SCHEMA_VER, ATTR_NAMES, sig, owner.address);
+      const id    = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(["string","string","string"], [ISSUER_DID, SCHEMA_NAME, SCHEMA_VER])
+      );
+      expect(await schemaRegistry.schemaExists(id)).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
…efRegistry

- didRegistrar: add _validateDid() — enforces exactly 3 colon-separated segments (matches chaincode's authzXcc.go:199 invariant); called first in createDid and updateDid before any storage read
- SchemaRegistry: new contract mirroring SchemaReceiver; stores schemas keyed by keccak256(issuerId, name, version); cross-validates issuer DID is Active; exposes schemaExists() for CredDefRegistry
- CredDefRegistry: new contract mirroring CredDefReceiver; keyed by keccak256(issuerId, schemaId, tag); cross-validates issuer DID and schemaId existence; value field is opaque bytes (CL key material)
- interfaces/IDidRegistry, ISchemaRegistry: minimal cross-contract interfaces
- 88 tests passing (6 DID format + 14 SchemaRegistry + 11 CredDefRegistry
  + 57 existing DID registry tests); all written TDD before implementation